### PR TITLE
Improve test configuration and import paths

### DIFF
--- a/pattern_based_extractor.py
+++ b/pattern_based_extractor.py
@@ -1,0 +1,52 @@
+"""Simple pattern-based extractor used in tests.
+
+This lightweight implementation provides placeholder
+structures for financial, operational and news data
+extraction. The methods perform minimal processing and
+return empty results, allowing tests to import the module
+without requiring the full production implementation.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Any
+
+
+@dataclass
+class FinancialData:
+    """Placeholder container for financial information."""
+    items: List[Any] = field(default_factory=list)
+
+
+@dataclass
+class OperationalData:
+    """Placeholder container for operational information."""
+    items: List[Any] = field(default_factory=list)
+
+
+@dataclass
+class NewsItem:
+    """Representation of a news item discovered during scraping."""
+    title: str = ""
+    category: str = ""
+    relevance_score: float = 0.0
+
+
+class PatternBasedExtractor:
+    """Minimal extractor implementing the interface used in tests."""
+
+    def extract_financial_data(self, content: str) -> FinancialData:
+        """Return placeholder financial data."""
+        return FinancialData()
+
+    def extract_operational_data(self, content: str) -> OperationalData:
+        """Return placeholder operational data."""
+        return OperationalData()
+
+    def extract_news_items(self, content: str, source: str) -> List[NewsItem]:
+        """Return an empty list of news items."""
+        return []
+
+    def extract_dates(self, content: str) -> List[str]:
+        """Return an empty list of date strings."""
+        return []

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,10 +1,10 @@
-[tool:pytest]
+[pytest]
 minversion = 7.0
 testpaths = tests
 python_files = test_*.py *_test.py
 python_classes = Test*
 python_functions = test_*
-addopts = 
+addopts =
     --strict-markers
     --disable-warnings
     --tb=short

--- a/src/core/complete_mining_intelligence_system.py
+++ b/src/core/complete_mining_intelligence_system.py
@@ -575,8 +575,14 @@ async def main():
     print("🔥 Comprehensive sentiment analysis")
     print("🔥 Executive reporting")
     print("🔥 Database storage")
-    
+
     return data
+
+
+class CompleteMiningIntelligenceSystem(CompleteMiningIntelligence):
+    """Backward compatible alias for legacy imports."""
+
+    pass
 
 if __name__ == "__main__":
     results = asyncio.run(main())

--- a/src/scrapers/__init__.py
+++ b/src/scrapers/__init__.py
@@ -37,7 +37,7 @@ from .unified_scraper import UnifiedScraper, ScrapingStrategy, ScrapingResult
 from .scraper_intelligence import ScraperIntelligence
 
 # Configuration
-from ..utils.scraper_config import load_scraper_config
+from utils.scraper_config import load_scraper_config
 
 __all__ = [
     # Main interface functions

--- a/src/scrapers/financial_data_scraper.py
+++ b/src/scrapers/financial_data_scraper.py
@@ -9,7 +9,7 @@ import re
 from typing import List, Dict, Any, Optional
 from datetime import datetime
 from .unified_scraper import UnifiedScraper, ScrapingStrategy, ScrapingResult
-from ..utils.scraper_config import load_scraper_config
+from utils.scraper_config import load_scraper_config
 
 class FinancialDataScraper:
     """Specialized scraper for financial and market data"""

--- a/src/scrapers/mining_news_scraper.py
+++ b/src/scrapers/mining_news_scraper.py
@@ -8,7 +8,7 @@ import asyncio
 from typing import List, Dict, Any
 from datetime import datetime
 from .unified_scraper import UnifiedScraper, ScrapingStrategy, ScrapingResult
-from ..utils.scraper_config import load_scraper_config
+from utils.scraper_config import load_scraper_config
 
 class MiningNewsScraper:
     """Specialized scraper for mining industry news"""

--- a/src/scrapers/scraper_factory.py
+++ b/src/scrapers/scraper_factory.py
@@ -12,7 +12,7 @@ from .unified_scraper import UnifiedScraper, ScrapingStrategy
 from .mining_news_scraper import MiningNewsScraper
 from .financial_data_scraper import FinancialDataScraper
 from .scraper_intelligence import ScraperIntelligence
-from ..utils.scraper_config import load_scraper_config
+from utils.scraper_config import load_scraper_config
 
 class ScraperFactory:
     """Central factory for all scraping operations"""


### PR DESCRIPTION
## Summary
- configure pytest properly and avoid unwanted root-level tests
- fix scrapers to use absolute configuration imports
- add compatibility alias for renamed mining intelligence system
- provide a lightweight PatternBasedExtractor for test imports

## Testing
- `pytest -q --override-ini addopts=''` *(fails: sqlite3.OperationalError: unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_68912ed550a48321987aecb39f0869b7